### PR TITLE
[fetch] Use long command line options for better readability

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -9,22 +9,22 @@ cores=$(nproc)
 manifest_dir="${MANIFEST_DIR?}"
 manifest_repo="${MANIFEST_REPO?}"
 
-mkdir -p "${base_dir}" "${manifest_dir}"
+mkdir --parents "${base_dir}" "${manifest_dir}"
 
-rsync -Pav "${manifest_repo}/" "${manifest_dir}/"
+rsync -P --archive --verbose "${manifest_repo}/" "${manifest_dir}/"
 
 [ -d "${manifest_dir}/.git" ] || {
 	export GIT_WORK_TREE="$manifest_dir"
 	export GIT_DIR="${manifest_dir}/.git"
 	git init
 	git add .
-	git commit -a -m "automated cache commit"
+	git commit --all --message "automated cache commit"
 }
 
 cd "${base_dir}"
 
-repo init -u "${manifest_dir}" -m base.xml
+repo init --manifest-url "${manifest_dir}" --manifest-name base.xml
 
-retry 3 repo sync -c --no-tags --no-clone-bundle --jobs "${cores}"
+retry 3 repo sync --current-branch --no-tags --no-clone-bundle --jobs "${cores}"
 
-repo forall -c 'git reset --hard ; git clean -fdx'
+repo forall -c 'git reset --hard ; git clean --force -dx'


### PR DESCRIPTION
I find it important, specially for security focused projects, to be as easy to review and understand as possible. I think using long command line options helps with this as they better document the code without the need to look them all up.

If you agree, the other scripts could be updated as well.