### PR TITLE
[fetch] Use long command line options for better readability (only approved changes of #27)

### DIFF
--- a/scripts/fetch
+++ b/scripts/fetch
@@ -23,8 +23,8 @@ rsync -Pav "${manifest_repo}/" "${manifest_dir}/"
 
 cd "${base_dir}"
 
-repo init -u "${manifest_dir}" -m base.xml
+repo init --manifest-url "${manifest_dir}" --manifest-name base.xml
 
-retry 3 repo sync -c --no-tags --no-clone-bundle --jobs "${cores}"
+retry 3 repo sync --current-branch --no-tags --no-clone-bundle --jobs "${cores}"
 
 repo forall -c 'git reset --hard ; git clean -fdx'


### PR DESCRIPTION
I find it important, specially for security focused projects, to be as easy to review and understand as possible. I think using long command line options helps with this as they better document the code without the need to look them all up.

There is a tread-off here. Some short command line options are very common and using the long variants instead might just feel wired. So we still expect good knowledge of your GNU/Linux environment.

Approved changes of: https://github.com/hashbang/os/pull/27