### PR TITLE
[PATCH] Updated default maximum password length in DevicePolicyManager

### DIFF
--- a/patches/platform/increase-default-maximum-password-length.patch
+++ b/patches/platform/increase-default-maximum-password-length.patch
@@ -1,0 +1,24 @@
+From 1d7ddaf7708a50f230faa385ce5ec0a3e08adefe Mon Sep 17 00:00:00 2001
+From: Travis Laporte <travis@openshroud.com>
+Date: Sun, 11 Nov 2018 12:38:05 -0500
+Subject: [PATCH] Updated default maximum password length in DevicePolicyManager
+
+---
+ frameworks/base/core/java/android/app/admin/DevicePolicyManager.java | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java b/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
+index 22367b21221..04b81b9404a 100644
+--- a/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
++++ b/frameworks/base/core/java/android/app/admin/DevicePolicyManager.java
+@@ -2765,7 +2765,7 @@ public class DevicePolicyManager {
+      */
+     public int getPasswordMaximumLength(int quality) {
+         // Kind-of arbitrary.
+-        return 16;
++        return 64;
+     }
+
+     /**
+--
+2.19.1.windows.1


### PR DESCRIPTION
Source and credits go to: @tlaporte
Ref: https://github.com/RattlesnakeOS/community_patches/pull/4
Related to: #24